### PR TITLE
Symbolize keys in ruby example

### DIFF
--- a/ruby/Ch03-Msgy-Schema/Msgy.rb
+++ b/ruby/Ch03-Msgy-Schema/Msgy.rb
@@ -24,6 +24,7 @@ class Timeline < Hashie::Dash
 end
 
 class UserRepository
+  include Hashie::Extensions::SymbolizeKeys
   BUCKET = 'Users'
 
   def initialize(client)
@@ -42,11 +43,12 @@ class UserRepository
 
   def get(user_name)
     riak_obj = @client.bucket(BUCKET)[user_name]
-    User.new(riak_obj.data)
+    User.new(riak_obj.data.symbolize_keys)
   end
 end
 
 class MsgRepository
+  include Hashie::Extensions::SymbolizeKeys
   BUCKET = 'Msgs'
 
   def initialize(client)
@@ -67,7 +69,7 @@ class MsgRepository
 
   def get(key)
     riak_obj = @client.bucket(BUCKET).get(key)
-    Msg.new(riak_obj.data)
+    Msg.new(riak_obj.data.symbolize_keys)
   end
 
   def generate_key(msg)
@@ -76,6 +78,7 @@ class MsgRepository
 end
 
 class TimelineRepository
+  include Hashie::Extensions::SymbolizeKeys
   BUCKET = 'Timelines'
   SENT = 'Sent'
   INBOX = 'Inbox'
@@ -96,7 +99,7 @@ class TimelineRepository
 
   def get_timeline(owner, type, date)
     riak_obj = @client.bucket(BUCKET).get(generate_key(owner, type, date))
-    Timeline.new(riak_obj.data)
+    Timeline.new(riak_obj.data.symbolize_keys)
   end
 
   private
@@ -126,7 +129,7 @@ class TimelineRepository
 
   def add_to_existing_timeline(key, msg_key)
     riak_obj = @client.bucket(BUCKET).get(key)
-    timeline = Timeline.new(riak_obj.data)
+    timeline = Timeline.new(riak_obj.data.symbolize_keys)
     timeline.msgs << msg_key
     riak_obj.data = timeline
     riak_obj


### PR DESCRIPTION
In [UserRepository.get()](https://github.com/basho/taste-of-riak/blob/master/ruby/Ch03-Msgy-Schema/Msgy.rb#L45) in the ruby example, the re-created user object doesn't quite work.

When the object is serialized into JSON, the symbols in the hash (:user_name) get turned into "user_name" instead. When they're loaded again, hashie doesn't automatically map those over to the symbols it expects.

One workaround would be to use `include Hashie::Extensions::SymbolizeKeys` and then `User.new(riak_obj.data.symbolize_keys)`.

This PR adds several cases of `include Hashie::Extensions::SymbolizeKeys` and switches all object creation to `riak_obj.data.symbolize_keys`

Without this, running the code results in errors like:
```
/Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:189:in `fail_no_property_error!': The property 'owner' is not defined for Timeline. (NoMethodError)
	from /Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:167:in `assert_property_exists!'
	from /Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:119:in `[]='
	from /Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:162:in `block in initialize_attributes'
	from /Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:161:in `each_pair'
	from /Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:161:in `initialize_attributes'
	from /Users/danieldreier/.rvm/gems/ruby-2.1.2@tasteofruby/gems/hashie-3.3.1/lib/hashie/dash.rb:93:in `initialize'
	from Msgy.rb:102:in `new'
	from Msgy.rb:102:in `get_timeline'
	from Msgy.rb:180:in `<main>'
```

Thanks for your awesome documentation and examples. Getting started with riak / ruby has been really straightforward.